### PR TITLE
Fixed arguments; Add support for environment Variables

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ function depVer(dependency)
 function buildDependencies(PKG, dependenciesField, argv, callback)
 {
   // Adjust the arguments
-  if(argv instanceof Array || argv instanceof Function)
+  if(argv instanceof Function)
   {
     callback = argv
     argv = dependenciesField
@@ -43,13 +43,13 @@ function buildDependencies(PKG, dependenciesField, argv, callback)
     if(finished) return
     finished = true
 
-    callback(errCode || signal)
+    return callback(errCode || signal)
   }
 
   buildDependencies.unshift('install')
   Array.prototype.push.apply(buildDependencies, argv)
 
-  spawn('npm', buildDependencies, {stdio: 'inherit'})
+  spawn('npm', buildDependencies, {stdio: 'inherit', env: process.env })
   .on('error', errorOrExit)
   .on('exit', errorOrExit)
 }

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ function depVer(dependency)
 function buildDependencies(PKG, dependenciesField, argv, callback)
 {
   // Adjust the arguments
-  if(argv instanceof Function)
+  if(dependenciesField instanceof Array || dependenciesField instanceof Function)
   {
     callback = argv
     argv = dependenciesField
@@ -43,7 +43,7 @@ function buildDependencies(PKG, dependenciesField, argv, callback)
     if(finished) return
     finished = true
 
-    return callback(errCode || signal)
+    callback(errCode || signal)
   }
 
   buildDependencies.unshift('install')


### PR DESCRIPTION
Fixed the arguments; Return statement on returning a callback to end code execution in the errorOrExit callback; You can set environment variables needed for some applications like nodegit (on Arch linux it needs BUILD_ONLY=1) to build from scratch otherwise it would loudly fail